### PR TITLE
Add 'Disable Click' feature to view settings

### DIFF
--- a/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
+++ b/apps/readest-app/src/app/reader/components/FoliateViewer.tsx
@@ -162,6 +162,9 @@ const FoliateViewer: React.FC<{
       if (msg.data && msg.data.bookKey === bookKey) {
         const viewSettings = getViewSettings(bookKey)!;
         if (msg.data.type === 'iframe-single-click') {
+          if (viewSettings.disableClick!) {
+            return;
+          }
           const viewElement = containerRef.current;
           if (viewElement) {
             const rect = viewElement.getBoundingClientRect();

--- a/apps/readest-app/src/app/reader/components/ViewMenu.tsx
+++ b/apps/readest-app/src/app/reader/components/ViewMenu.tsx
@@ -28,7 +28,6 @@ const ViewMenu: React.FC<ViewMenuProps> = ({
   const { themeMode, isDarkMode, themeCode, updateThemeMode } = useTheme();
   const [isScrolledMode, setScrolledMode] = useState(viewSettings!.scrolled);
   const [isInvertedColors, setInvertedColors] = useState(viewSettings!.invert);
-  const [isDisableClick, setIsDisableClick] = useState(viewSettings!.disableClick);
   const [zoomLevel, setZoomLevel] = useState(viewSettings!.zoomLevel!);
 
   const zoomIn = () => setZoomLevel((prev) => Math.min(prev + 10, 200));
@@ -36,7 +35,6 @@ const ViewMenu: React.FC<ViewMenuProps> = ({
   const resetZoom = () => setZoomLevel(100);
   const toggleScrolledMode = () => setScrolledMode(!isScrolledMode);
   const toggleInvertedColors = () => setInvertedColors(!isInvertedColors);
-  const toggleDisableClick = () => setIsDisableClick(!isDisableClick);
 
   const openFontLayoutMenu = () => {
     setIsDropdownOpen?.(false);
@@ -85,14 +83,6 @@ const ViewMenu: React.FC<ViewMenuProps> = ({
     setViewSettings(bookKey, viewSettings!);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [zoomLevel]);
-
-  useEffect(() => {
-    const view = getView(bookKey);
-    if (!view) return;
-    viewSettings!.disableClick = isDisableClick;
-    setViewSettings(bookKey, viewSettings!);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isDisableClick]);
 
   return (
     <div
@@ -143,13 +133,6 @@ const ViewMenu: React.FC<ViewMenuProps> = ({
         shortcut='Shift+J'
         icon={isScrolledMode ? <MdCheck size={20} /> : undefined}
         onClick={toggleScrolledMode}
-      />
-
-      <MenuItem
-          label='Disable Click'
-          shortcut='Shift+D'
-          icon={isDisableClick ? <MdCheck size={20} /> : undefined}
-          onClick={toggleDisableClick}
       />
 
       <hr className='border-base-200 my-1' />

--- a/apps/readest-app/src/app/reader/components/ViewMenu.tsx
+++ b/apps/readest-app/src/app/reader/components/ViewMenu.tsx
@@ -28,6 +28,7 @@ const ViewMenu: React.FC<ViewMenuProps> = ({
   const { themeMode, isDarkMode, themeCode, updateThemeMode } = useTheme();
   const [isScrolledMode, setScrolledMode] = useState(viewSettings!.scrolled);
   const [isInvertedColors, setInvertedColors] = useState(viewSettings!.invert);
+  const [isDisableClick, setIsDisableClick] = useState(viewSettings!.disableClick);
   const [zoomLevel, setZoomLevel] = useState(viewSettings!.zoomLevel!);
 
   const zoomIn = () => setZoomLevel((prev) => Math.min(prev + 10, 200));
@@ -35,6 +36,7 @@ const ViewMenu: React.FC<ViewMenuProps> = ({
   const resetZoom = () => setZoomLevel(100);
   const toggleScrolledMode = () => setScrolledMode(!isScrolledMode);
   const toggleInvertedColors = () => setInvertedColors(!isInvertedColors);
+  const toggleDisableClick = () => setIsDisableClick(!isDisableClick);
 
   const openFontLayoutMenu = () => {
     setIsDropdownOpen?.(false);
@@ -83,6 +85,14 @@ const ViewMenu: React.FC<ViewMenuProps> = ({
     setViewSettings(bookKey, viewSettings!);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [zoomLevel]);
+
+  useEffect(() => {
+    const view = getView(bookKey);
+    if (!view) return;
+    viewSettings!.disableClick = isDisableClick;
+    setViewSettings(bookKey, viewSettings!);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isDisableClick]);
 
   return (
     <div
@@ -133,6 +143,13 @@ const ViewMenu: React.FC<ViewMenuProps> = ({
         shortcut='Shift+J'
         icon={isScrolledMode ? <MdCheck size={20} /> : undefined}
         onClick={toggleScrolledMode}
+      />
+
+      <MenuItem
+          label='Disable Click'
+          shortcut='Shift+D'
+          icon={isDisableClick ? <MdCheck size={20} /> : undefined}
+          onClick={toggleDisableClick}
       />
 
       <hr className='border-base-200 my-1' />

--- a/apps/readest-app/src/app/reader/components/settings/MiscPanel.tsx
+++ b/apps/readest-app/src/app/reader/components/settings/MiscPanel.tsx
@@ -1,4 +1,4 @@
-import React, { use, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useReaderStore } from '@/store/readerStore';
 import { useSettingsStore } from '@/store/settingsStore';
 import cssbeautify from 'cssbeautify';

--- a/apps/readest-app/src/app/reader/components/settings/MiscPanel.tsx
+++ b/apps/readest-app/src/app/reader/components/settings/MiscPanel.tsx
@@ -15,6 +15,7 @@ const MiscPanel: React.FC<{ bookKey: string }> = ({ bookKey }) => {
   const { themeCode } = useTheme();
 
   const [animated, setAnimated] = useState(viewSettings.animated!);
+  const [isDisableClick, setIsDisableClick] = useState(viewSettings.disableClick!);
   const [userStylesheet, setUserStylesheet] = useState(viewSettings.userStylesheet!);
   const [error, setError] = useState<string | null>(null);
 
@@ -73,6 +74,12 @@ const MiscPanel: React.FC<{ bookKey: string }> = ({ bookKey }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [animated]);
 
+  useEffect(() => {
+    viewSettings!.disableClick = isDisableClick;
+    setViewSettings(bookKey, viewSettings!);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isDisableClick]);
+
   return (
     <div className='my-4 w-full space-y-6'>
       <div className='w-full'>
@@ -86,6 +93,23 @@ const MiscPanel: React.FC<{ bookKey: string }> = ({ bookKey }) => {
                 className='toggle'
                 checked={animated}
                 onChange={() => setAnimated(!animated)}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className='w-full'>
+        <h2 className='mb-2 font-medium'>Control</h2>
+        <div className='card bg-base-100 border shadow'>
+          <div className='divide-y'>
+            <div className='config-item config-item-top config-item-bottom'>
+              <span className='text-gray-700'>Disable Page Turn on Click</span>
+              <input
+                type='checkbox'
+                className='toggle'
+                checked={isDisableClick}
+                onChange={() => setIsDisableClick(!isDisableClick)}
               />
             </div>
           </div>

--- a/apps/readest-app/src/app/reader/components/settings/MiscPanel.tsx
+++ b/apps/readest-app/src/app/reader/components/settings/MiscPanel.tsx
@@ -61,9 +61,11 @@ const MiscPanel: React.FC<{ bookKey: string }> = ({ bookKey }) => {
 
   useEffect(() => {
     viewSettings.animated = animated;
+    viewSettings.disableClick = isDisableClick;
     setViewSettings(bookKey, viewSettings);
     if (isFontLayoutSettingsGlobal) {
       settings.globalViewSettings.animated = animated;
+      settings.globalViewSettings.disableClick = isDisableClick;
       setSettings(settings);
     }
     if (animated) {
@@ -72,13 +74,7 @@ const MiscPanel: React.FC<{ bookKey: string }> = ({ bookKey }) => {
       getView(bookKey)?.renderer.removeAttribute('animated');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [animated]);
-
-  useEffect(() => {
-    viewSettings!.disableClick = isDisableClick;
-    setViewSettings(bookKey, viewSettings!);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isDisableClick]);
+  }, [animated,isDisableClick]);
 
   return (
     <div className='my-4 w-full space-y-6'>

--- a/apps/readest-app/src/app/reader/components/settings/MiscPanel.tsx
+++ b/apps/readest-app/src/app/reader/components/settings/MiscPanel.tsx
@@ -100,11 +100,11 @@ const MiscPanel: React.FC<{ bookKey: string }> = ({ bookKey }) => {
       </div>
 
       <div className='w-full'>
-        <h2 className='mb-2 font-medium'>Control</h2>
+        <h2 className='mb-2 font-medium'>Behavior</h2>
         <div className='card bg-base-100 border shadow'>
           <div className='divide-y'>
             <div className='config-item config-item-top config-item-bottom'>
-              <span className='text-gray-700'>Disable Page Turn on Click</span>
+              <span className='text-gray-700'>Disable Click-to-Flip</span>
               <input
                 type='checkbox'
                 className='toggle'

--- a/apps/readest-app/src/app/reader/components/settings/MiscPanel.tsx
+++ b/apps/readest-app/src/app/reader/components/settings/MiscPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { use, useEffect, useState } from 'react';
 import { useReaderStore } from '@/store/readerStore';
 import { useSettingsStore } from '@/store/settingsStore';
 import cssbeautify from 'cssbeautify';
@@ -61,11 +61,9 @@ const MiscPanel: React.FC<{ bookKey: string }> = ({ bookKey }) => {
 
   useEffect(() => {
     viewSettings.animated = animated;
-    viewSettings.disableClick = isDisableClick;
     setViewSettings(bookKey, viewSettings);
     if (isFontLayoutSettingsGlobal) {
       settings.globalViewSettings.animated = animated;
-      settings.globalViewSettings.disableClick = isDisableClick;
       setSettings(settings);
     }
     if (animated) {
@@ -74,7 +72,17 @@ const MiscPanel: React.FC<{ bookKey: string }> = ({ bookKey }) => {
       getView(bookKey)?.renderer.removeAttribute('animated');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [animated,isDisableClick]);
+  }, [animated]);
+
+  useEffect(() => {
+    viewSettings.disableClick = isDisableClick;
+    setViewSettings(bookKey, viewSettings);
+    if (isFontLayoutSettingsGlobal) {
+      settings.globalViewSettings.disableClick = isDisableClick;
+      setSettings(settings);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isDisableClick]);
 
   return (
     <div className='my-4 w-full space-y-6'>

--- a/apps/readest-app/src/services/constants.ts
+++ b/apps/readest-app/src/services/constants.ts
@@ -38,6 +38,7 @@ export const DEFAULT_BOOK_LAYOUT: BookLayout = {
   marginPx: 44,
   gapPercent: 5,
   scrolled: false,
+  disableClick: false,
   maxColumnCount: 2,
   maxInlineSize: 720,
   maxBlockSize: 1440,

--- a/apps/readest-app/src/types/book.ts
+++ b/apps/readest-app/src/types/book.ts
@@ -40,6 +40,7 @@ export interface BookLayout {
   marginPx: number;
   gapPercent: number;
   scrolled: boolean;
+  disableClick: boolean;
   maxColumnCount: number;
   maxInlineSize: number;
   maxBlockSize: number;


### PR DESCRIPTION
## Description
This PR introduces the functionality to disable single-click actions in the ebook reader. The following changes have been made:

- Added a new setting disableClick to the BookLayout interface and DEFAULT_BOOK_LAYOUT.
- Updated FoliateViewer.tsx to check for the disableClick setting and prevent single-click actions if enabled.
- Enhanced ViewMenu.tsx to include a menu item that allows users to toggle the disableClick setting.
- Implemented state management for disableClick in the ViewMenu component and ensured changes are persisted in the view settings.

## Related Issues
#16 

## Testing
- Verified that the disableClick setting can be toggled through the ViewMenu.
- Confirmed that single-click actions are disabled when the setting is enabled and re-enabled when the setting is disabled.

## Known Issue
- The disable setting for the edge area (corner) is not functioning as intended.